### PR TITLE
Fix bug - Change check_if_title_exists fun

### DIFF
--- a/.github/workflows/roscron-check-standard.yaml
+++ b/.github/workflows/roscron-check-standard.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - fix-gha
+      - fix-dataset-name
   pull_request:
     branches:
       - master

--- a/R/extract.R
+++ b/R/extract.R
@@ -267,7 +267,8 @@ extract_dataset_name <- function(data_list) {
   # always pick the first language, assuming that there's at least one
   # because the previous check makes sure there is at least one
 
-  check_if_title_exists <- function(x) if ("title" %in% names(x)) x$title[[1]] else "Distribucion sin nombre"
+  check_if_title_exists <- function(x) if ("title" %in% names(x[[1]])) x[[1]]$title[[1]][['_value']] else "Distribucion sin nombre"
+
 
   data_set_names <-
     vapply(distribution,


### PR DESCRIPTION
The `extract_dataset_name()` function was failing due to an internal change in the API. The dataset title couldn't be extracted under the previous definition as the access slot didn't exist.

I had to adapt the `check_if_title_exists()` function in order to sort this out.